### PR TITLE
Added workaround for unavailable price

### DIFF
--- a/schiene/schiene.py
+++ b/schiene/schiene.py
@@ -11,6 +11,12 @@ def parse_connections(html):
 
     for row in soup.find_all("td", class_="overview timelink")[1:]:
         columns = row.parent.find_all("td")
+
+        try:
+            price = columns[3].contents[3].string.strip().replace(',', '.')
+        except IndexError:
+            price = ''
+
         data = {
             'details': columns[0].a.get('href'),
             'departure': columns[0].a.contents[0].string,
@@ -18,7 +24,7 @@ def parse_connections(html):
             'transfers': int(columns[2].contents[0]),
             'time': columns[2].contents[2],
             'products': columns[3].contents[0].split(', '),
-            'price': columns[3].contents[3].string.strip().replace(',', '.')
+            'price': price
         }
 
         if data['price'] == "":


### PR DESCRIPTION
Hello!

When using the API to look for trains in different countries (e.g. Italy) I get an `IndexError` in case the pricing is `Es gilt Auslandstarif` and not disclosed on Bahn.de:

```
[lorenzo@elisa ~/Devel/pivello]$ python trains.py 
Traceback (most recent call last):
  File "trains.py", line 3, in <module>
    print(s.connections('Novara', 'Vercelli'))
  File "/usr/lib/python3.5/site-packages/schiene/schiene.py", line 94, in connections
    return parse_connections(rsp.text)
  File "/usr/lib/python3.5/site-packages/schiene/schiene.py", line 21, in parse_connections
    'price': columns[3].contents[3].string.strip().replace(',', '.')
IndexError: list index out of range
```

I've worked around the issue by catching the IndexError and setting the price to an empty string in case the parsing fails (your code then converts '' into None anyway).

Thanks! 