### PR TITLE
Capture also minor delays

### DIFF
--- a/schiene/schiene.py
+++ b/schiene/schiene.py
@@ -54,7 +54,7 @@ def parse_delay(data):
     soup = BeautifulSoup(rsp.text, "html.parser")
 
     # get departure delay
-    delay_departure_raw = soup.find('div', class_="routeStart").find('span', class_=["delay","delayOnTime"])
+    delay_departure_raw = soup.find('div', class_="routeStart").find('span', class_=["delay", "delayOnTime"])
     if delay_departure_raw:
         delay_departure = calculate_delay(data['departure'],
                                           delay_departure_raw.text)
@@ -62,7 +62,7 @@ def parse_delay(data):
         delay_departure = 0
 
     # get arrival delay
-    delay_arrival_raw = soup.find('div', class_="routeEnd").find('span', class_=["delay","delayOnTime"])
+    delay_arrival_raw = soup.find('div', class_="routeEnd").find('span', class_=["delay", "delayOnTime"])
     if delay_arrival_raw:
         delay_arrival = calculate_delay(data['arrival'],
                                         delay_arrival_raw.text)

--- a/schiene/schiene.py
+++ b/schiene/schiene.py
@@ -28,7 +28,7 @@ def parse_connections(html):
             'price': price
         }
 
-        if not columns[1].find('img') and not columns[1].find('span', class_='delay'):
+        if not columns[1].find('img') and not columns[1].find('span', class_='delay') and not columns[1].find('span', class_='delayOnTime'):
             data['ontime'] = True
             data['canceled'] = False
         else:
@@ -54,7 +54,7 @@ def parse_delay(data):
     soup = BeautifulSoup(rsp.text, "html.parser")
 
     # get departure delay
-    delay_departure_raw = soup.find('div', class_="routeStart").find('span', class_="delay")
+    delay_departure_raw = soup.find('div', class_="routeStart").find('span', class_=["delay","delayOnTime"])
     if delay_departure_raw:
         delay_departure = calculate_delay(data['departure'],
                                           delay_departure_raw.text)
@@ -62,7 +62,7 @@ def parse_delay(data):
         delay_departure = 0
 
     # get arrival delay
-    delay_arrival_raw = soup.find('div', class_="routeEnd").find('span', class_="delay")
+    delay_arrival_raw = soup.find('div', class_="routeEnd").find('span', class_=["delay","delayOnTime"])
     if delay_arrival_raw:
         delay_arrival = calculate_delay(data['arrival'],
                                         delay_arrival_raw.text)


### PR DESCRIPTION
This captures also minor delays ("delayOnTime" < 5 min). 

Rationale: I am using the home-assistant component based on schiene and intend to use this information for delay warnings. As we live very close to the station, minutes matter and I was missing the exact delays. 

Generally, I think, it should be left up to the user to decide, if a delay is considered "on time" or not. However, the "onTIme" field could still be set only if the delay is more than 5 minutes. I am not sure, if this would imply greater changes, so my PR contains also a changed behavior for "onTime". It is false, as soon, as there is a delay. Even if the delay is less than 5 minutes.

I tested this in my home assistant setup and it works.