### PR TITLE
Remove shebang

### DIFF
--- a/schiene/schiene.py
+++ b/schiene/schiene.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import requests
 import json
 from datetime import datetime


### PR DESCRIPTION
The shebang is not needed for Python modules.