### PR TITLE
fix delayed time gets wrongly calculated if delay is in the next day

### DIFF
--- a/schiene/schiene.py
+++ b/schiene/schiene.py
@@ -100,7 +100,12 @@ def calculate_delay(original, delay):
     """
     original = datetime.strptime(original, '%H:%M')
     delayed = datetime.strptime(delay, '%H:%M')
-    diff = delayed - original
+    # if the original time was before 0:00 and the delayed time is in the new day, we need to do a different calculation
+    if delay_departure < delay_arrival:
+        fullday = 86400
+        diff = fullday - original + delayed
+    else:
+        diff = delayed - original
     return diff.total_seconds() // 60
 
 


### PR DESCRIPTION
This issue was detected by: https://github.com/FaserF/ha-deutschebahn/issues/1
This pull request should hopefully fix this.

The problem is the following:

Example 1:

delayed: 900 (00:15)
original: 85500 (23:45)

fullday: 86400 (24:00)

Right now: delayed - original = negative number (incorrect)
Correct: fullday - original + delayed
86400 - 85500 + 900 = 1800 (30 Minutes)

Example 2: 

delayed: 1020 (00:17)
original: 82320 (22:52)

fullday: 86400 (24:00)

Right now: delayed - original = negative number (incorrect)
Correct: fullday - original + delayed
86400 - 82320 + 1020 = 5100 (85 Minutes - 1 hour 25 minutes)


